### PR TITLE
(performance): fix double query execution when exceeding sizecap

### DIFF
--- a/src/jsoniqmagic/magic.py
+++ b/src/jsoniqmagic/magic.py
@@ -157,8 +157,7 @@ validate type mytype* {
                 print("Usual reasons: firewall, misconfigured proxy.")
                 return  
             if len(capplusone) > rumble.getRumbleConf().getResultSizeCap():
-                count = response.count()
-                print("The query output %s items, which is too many to display. Displaying the first %s items:" % (count, rumble.getRumbleConf().getResultSizeCap()))
+                print("The query output too many items to display. Displaying the first %s items:" % (rumble.getRumbleConf().getResultSizeCap()))
             for e in capplusone[:rumble.getRumbleConf().getResultSizeCap()]:
                 print(json.dumps(json.loads(e.serializeAsJSON()), indent=2))
 


### PR DESCRIPTION
## Expected behavior

When a query exceeds the configured `conf.setResultSizeCap(...)`, the output should be limited to the configured cap. Nothing else should happen underneath.

## Current behavior

When a query exceeds the configured `conf.setResultSizeCap(...)`, the query is re-executed through Spark, essentially causing it to execute twice.

## Case 1.1 - Correct behavior

<img width="800" alt="Case 1.1 - Query execution" src="https://github.com/user-attachments/assets/e47f24f3-1742-4a3f-b02f-46a49ed938c4" />

**Description:**
JSONiq uses local JVM execution. No Spark job is executed, and no jobs are shown in Spark.

<img width="400" alt="Case 1.1 - Spark jobs" src="https://github.com/user-attachments/assets/62fa67f7-ca3d-4ecd-bf48-6f253a54132e" />

## Case 1.2 - Unexpected behavior

<img width="800" alt="Case 1.2 - Query execution" src="https://github.com/user-attachments/assets/92abeb04-9316-42ef-a4b2-85c223587d15" />

**Description:**
JSONiq initially uses local JVM execution. Then, because the result exceeds `SizeCap(20)`, the extension triggers a second execution, this time on Spark.

<img width="400" alt="Case 1.2 - Spark jobs" src="https://github.com/user-attachments/assets/b269dd1a-9467-4097-8be0-192cdd594339" />

## Case 2.1 - Correct behavior

<img width="800" alt="Case 2.1 - Query execution" src="https://github.com/user-attachments/assets/19c73c65-81a9-4e41-93b4-d3de9b07edc8" />

**Description:**
JSONiq uses Spark to execute the query. The Spark job is executed exactly once.

<img width="400" alt="Case 2.1 - Spark jobs" src="https://github.com/user-attachments/assets/c53833bc-8eae-4f75-afdb-52331654921e" />

## Case 2.2 - Unexpected behavior

<img width="800" alt="Case 2.2 - Query execution" src="https://github.com/user-attachments/assets/9fa7ea7c-d39b-4cb1-83ff-823ad8450d9f" />

**Description:**
JSONiq uses Spark to execute the query. Then, because the result exceeds `SizeCap(20)`, the extension triggers a full second execution. As a result, the number of Spark jobs is doubled.

<img width="400" alt="Case 2.2 - Spark jobs" src="https://github.com/user-attachments/assets/8b2416c0-e9cb-4610-b748-d8fe9be66444" />
