### PR TITLE
(bug): fix magic accidentally overriding RumbleDB parameters

### DIFF
--- a/src/jsoniqmagic/__init__.py
+++ b/src/jsoniqmagic/__init__.py
@@ -4,6 +4,4 @@ from jsoniqmagic.magic import JSONiqMagic
 __all__ = ["JSONiqMagic"]
 
 def load_ipython_extension(ipython):
-    rumble = RumbleSession.builder.getOrCreate();
-    rumble.getRumbleConf().setResultSizeCap(10);
     ipython.register_magics(JSONiqMagic)


### PR DESCRIPTION
## Expected behavior

If the user has specified a RumbleDB instance in their notebook, the magic should not override the user configuration.

## Current behavior

`%load_ext jsoniqmagic` instantiates a default RumbleSession itself. If the user runs it *before* a Spark/RumbleDB setup cell, the JVM is created with default parameters and options like `spark.driver.memory=4g` are ignored. Spark runs with a 1 GiB heap instead of 4 GiB.

### Example 1:

<img width="1174" height="470" alt="image" src="https://github.com/user-attachments/assets/0de626d9-0fd9-4ee5-84c1-770d2f8ad386" />
<img width="1481" height="397" alt="image" src="https://github.com/user-attachments/assets/c114d433-8ef9-4b5a-a812-41c2b029f71c" />

**Description:**

The `%load_ext jsoniqmagic` overrides the user configuration. Spark is instantiated with the incorrect memory and shuffle partitions.

### Example 2:
<img width="1180" height="454" alt="image" src="https://github.com/user-attachments/assets/eddb7fb0-c56b-40bd-be94-5117841db709" />
<img width="1165" height="361" alt="image" src="https://github.com/user-attachments/assets/055f57a6-2b82-4c0a-a0ed-f643fde4af69" />

**Description:**

In this case `%load_ext jsoniqmagic` does not override the RumbleSession memory and shuffle partitions configuration. However, it overrides the setResultSizeCap configuration.